### PR TITLE
Fix crossorigin typo

### DIFF
--- a/components/ReactUtterances.tsx
+++ b/components/ReactUtterances.tsx
@@ -77,7 +77,7 @@ export class ReactUtterances extends React.Component<
     scriptElement.async = true
     scriptElement.defer = true
     scriptElement.setAttribute('repo', repo)
-    scriptElement.setAttribute('crossorigin', 'annonymous')
+    scriptElement.setAttribute('crossorigin', 'anonymous')
     scriptElement.setAttribute('theme', theme)
     scriptElement.onload = () => this.setState({ pending: false })
 


### PR DESCRIPTION
## Summary
- fix typo in ReactUtterances crossorigin attribute

## Testing
- `yarn test` *(fails: package not present in lockfile)*